### PR TITLE
Multiple improvments

### DIFF
--- a/pgrepup/commands/check.py
+++ b/pgrepup/commands/check.py
@@ -272,8 +272,8 @@ def checks(target, single_test=None, db_conn=None):
                 reusable_results['pg_dumpall'] = "Install postgresql client utils locally."
                 checks_result[c] = False
                 continue
-
-            version_rule = re.compile(".*(\d{1,2}\.\d{1,2}\.\d{1,2}|\d{2}\.\d{1,2}\.\d{1,2}|\d{2}\.\d{1,2}).*")
+            # see semver._REGEX
+            version_rule = re.compile(r""".*((?P<major>(?:0|[1-9][0-9]*))\.(?P<minor>(?:0|[1-9][0-9]*))\.(?P<patch>(?:0|[1-9][0-9]*))(\-(?P<prerelease>(?:0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*))?(\+(?P<build>[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?|\d{2}\.\d{1}).*""", re.VERBOSE)
             pg_dumpall_version = subprocess.check_output(["pg_dumpall", "--version"])
             pg_dumpall_version = version_rule.match(pg_dumpall_version)
             if not pg_dumpall_version:

--- a/pgrepup/commands/check.py
+++ b/pgrepup/commands/check.py
@@ -273,7 +273,7 @@ def checks(target, single_test=None, db_conn=None):
                 checks_result[c] = False
                 continue
             # see semver._REGEX
-            version_rule = re.compile(r""".*((?P<major>(?:0|[1-9][0-9]*))\.(?P<minor>(?:0|[1-9][0-9]*))\.(?P<patch>(?:0|[1-9][0-9]*))(\-(?P<prerelease>(?:0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*))?(\+(?P<build>[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?|\d{2}\.\d{1}).*""", re.VERBOSE)
+            version_rule = re.compile(r""".*pg_dumpall \(PostgreSQL\) ([0-9.]+).*""")
             pg_dumpall_version = subprocess.check_output(["pg_dumpall", "--version"])
             pg_dumpall_version = version_rule.match(pg_dumpall_version)
             if not pg_dumpall_version:

--- a/pgrepup/commands/config.py
+++ b/pgrepup/commands/config.py
@@ -58,6 +58,12 @@ def config(**kwargs):
         prompt.query("Folder where pgrepup store temporary dumps and pgpass file", "/tmp")
     )
 
+    conf.set(
+        "Security",
+        "app_owner",
+        prompt.query("Postgresql username as application owner", "app_owner")
+    )
+
     puts(colored.cyan("Source Database configuration"))
     conf.add_section("Source")
     conf.set("Source", "host", prompt.query("Ip address or Dns name: "))

--- a/pgrepup/commands/setup.py
+++ b/pgrepup/commands/setup.py
@@ -135,7 +135,8 @@ def _setup_source(conn, pg_pass):
             result[db] = True
             print(output_cli_result(True, compensation=4))
     # see https://www.2ndquadrant.com/en/resources/pglogical/pglogical-docs/ 2.4.1 Automatic Assignment of Replication Sets for New Tables
-    output_cli_message("Add trigger to add all new tables pglogical replication on Source node name")
+    # and https://github.com/enova/pgl_ddl_deploy
+    output_cli_message("Add triggers to replicate DDL statements on Source node")
     print
     with indent(4, quote=' '):
         for db in get_cluster_databases(conn):
@@ -177,7 +178,8 @@ def _setup_destination(conn, pg_pass, source_setup_results):
             print(output_cli_result(result[db], compensation=4))
 
     # see https://www.2ndquadrant.com/en/resources/pglogical/pglogical-docs/ 2.4.1 Automatic Assignment of Replication Sets for New Tables
-    output_cli_message("Add trigger to add all new tables pglogical replication on Destination node name")
+    # and https://github.com/enova/pgl_ddl_deploy
+    output_cli_message("Add triggers to replicate DDL statements on Destination node")
     print
     with indent(4, quote=' '):
         for db in get_cluster_databases(conn):

--- a/pgrepup/commands/setup.py
+++ b/pgrepup/commands/setup.py
@@ -140,7 +140,7 @@ def _setup_source(conn, pg_pass):
     with indent(4, quote=' '):
         for db in get_cluster_databases(conn):
             output_cli_message(db)
-            if not setup_pgl_ddl_deploy(db):
+            if not setup_pgl_ddl_deploy(db, target='Source'):
                 print(output_cli_result(False, compensation=4))
                 continue
             print(output_cli_result(True, compensation=4))
@@ -175,6 +175,17 @@ def _setup_destination(conn, pg_pass, source_setup_results):
             output_cli_message(db)
             result[db] = create_pglogical_node(db)
             print(output_cli_result(result[db], compensation=4))
+
+    # see https://www.2ndquadrant.com/en/resources/pglogical/pglogical-docs/ 2.4.1 Automatic Assignment of Replication Sets for New Tables
+    output_cli_message("Add trigger to add all new tables pglogical replication on Destination node name")
+    print
+    with indent(4, quote=' '):
+        for db in get_cluster_databases(conn):
+            output_cli_message(db)
+            if not setup_pgl_ddl_deploy(db, target='Destination'):
+                print(output_cli_result(False, compensation=4))
+                continue
+            print(output_cli_result(True, compensation=4))
 
     for db in get_cluster_databases(conn):
         store_setup_result('Destination', db, result[db] and result['result'])

--- a/pgrepup/commands/setup.py
+++ b/pgrepup/commands/setup.py
@@ -134,16 +134,16 @@ def _setup_source(conn, pg_pass):
                 continue
             result[db] = True
             print(output_cli_result(True, compensation=4))
-
-    # output_cli_message("Setup pglogical ddl replication on Source node name")
-    # print
-    # with indent(4, quote=' '):
-    #     for db in get_cluster_databases(conn):
-    #         output_cli_message(db)
-    #         if not setup_ddl_syncronization(db):
-    #             print(output_cli_result(False, compensation=4))
-    #             continue
-    #         print(output_cli_result(True, compensation=4))
+    # see https://www.2ndquadrant.com/en/resources/pglogical/pglogical-docs/ 2.4.1 Automatic Assignment of Replication Sets for New Tables
+    output_cli_message("Add trigger to add all new tables pglogical replication on Source node name")
+    print
+    with indent(4, quote=' '):
+        for db in get_cluster_databases(conn):
+            output_cli_message(db)
+            if not setup_ddl_syncronization(db):
+                print(output_cli_result(False, compensation=4))
+                continue
+            print(output_cli_result(True, compensation=4))
 
     for db in get_cluster_databases(conn):
         store_setup_result('Source', db, result[db] and result['result'])

--- a/pgrepup/commands/setup.py
+++ b/pgrepup/commands/setup.py
@@ -140,7 +140,7 @@ def _setup_source(conn, pg_pass):
     with indent(4, quote=' '):
         for db in get_cluster_databases(conn):
             output_cli_message(db)
-            if not setup_ddl_syncronization(db):
+            if not setup_pg_ddl_deploy(db):
                 print(output_cli_result(False, compensation=4))
                 continue
             print(output_cli_result(True, compensation=4))

--- a/pgrepup/commands/setup.py
+++ b/pgrepup/commands/setup.py
@@ -140,7 +140,7 @@ def _setup_source(conn, pg_pass):
     with indent(4, quote=' '):
         for db in get_cluster_databases(conn):
             output_cli_message(db)
-            if not setup_pg_ddl_deploy(db):
+            if not setup_pgl_ddl_deploy(db):
                 print(output_cli_result(False, compensation=4))
                 continue
             print(output_cli_result(True, compensation=4))

--- a/pgrepup/commands/setup.py
+++ b/pgrepup/commands/setup.py
@@ -112,7 +112,7 @@ def _setup_source(conn, pg_pass):
     pg_dumpall_schema = "%s/pg_dumpall_schema_%s.sql" % (get_tmp_folder(), uuid.uuid4().hex)
     output_cli_message("Dump globals and schema of all databases")
     pg_dumpall_schema_result = \
-        os.system("PGPASSFILE=%(pgpass)s pg_dumpall -U %(user)s -h %(host)s -p%(port)s -s -f %(fname)s --if-exists -c" %
+        os.system('sh -c "PGPASSFILE=%(pgpass)s pg_dumpall -U %(user)s -h %(host)s -p%(port)s -s -f %(fname)s --if-exists -c"' %
                   merge_two_dicts(
                       get_connection_params('Source'),
                       {"fname": pg_dumpall_schema, "pgpass": pg_pass}
@@ -156,7 +156,7 @@ def _setup_destination(conn, pg_pass, source_setup_results):
     if source_setup_results.has_key('pg_dumpall'):
         restore_schema_result = \
             os.system(
-                "PGPASSFILE=%(pgpass)s psql -U %(user)s -h %(host)s -p%(port)s -f %(fname)s -d postgres >/dev/null 2>&1"
+                'sh -c "PGPASSFILE=%(pgpass)s psql -U %(user)s -h %(host)s -p%(port)s -f %(fname)s -d postgres >/dev/null 2>&1"'
                 % merge_two_dicts(
                     get_connection_params('Destination'),
                     {"fname": source_setup_results['pg_dumpall'], "pgpass": pg_pass}

--- a/pgrepup/commands/status.py
+++ b/pgrepup/commands/status.py
@@ -56,7 +56,7 @@ def status(**kwargs):
     output_cli_message("Replication status", color='cyan')
     puts("")
     with indent(4, quote=' >'):
-        for db in get_cluster_databases(connect(t)):
+        for db in get_cluster_databases(connect('Destination')):
             output_cli_message("Database %s" % db)
             if not (setup_results['Source'][db] and setup_results['Destination'][db] and
                     check_results['Source'] and check_results['Destination']):

--- a/pgrepup/commands/uninstall.py
+++ b/pgrepup/commands/uninstall.py
@@ -34,6 +34,20 @@ def uninstall(**kwargs):
                 output_cli_message(db)
                 drop_node(db)
                 print(output_cli_result(True, 4))
+        output_cli_message("Drop pgl_ddl_deploy extension in all databases")
+        print
+        with indent(4, quote=' '):
+            for t in ['Source', 'Destination']:
+                output_cli_message(t)
+                print
+                with indent(4, quote=' '):
+                    for db in get_cluster_databases(connect(t)):
+                        output_cli_message(db)
+                        if not clean_pgl_ddl_deploy(t, db):
+                            print(output_cli_result(False, compensation=8))
+                            continue
+                        print(output_cli_result(True, compensation=8))
+
 
         output_cli_message("Drop pg_logical extension in all databases")
         print

--- a/pgrepup/commands/uninstall.py
+++ b/pgrepup/commands/uninstall.py
@@ -68,22 +68,22 @@ def uninstall(**kwargs):
 
         output_cli_message("Drop unique fields added by fix command")
         print
-        with indent(4, quote=' '):
+        with indent(8, quote=' '):
             src_db_conn = connect('Source')
-            dest_db_conn = connect('Destination')
-            with indent(4, quote=' '):
-                for db in get_cluster_databases(src_db_conn):
-                    output_cli_message(db)
-                    print
-                    src_d_db_conn = connect('Source', db_name=db)
-                    dest_d_db_conn = connect('Destination', db_name=db)
-                    with indent(4, quote=' '):
-                        for table in get_database_tables(src_d_db_conn):
-                            output_cli_message("%s.%s" % (table['schema'], table['table']))
-                            s = drop_table_field(src_d_db_conn,
-                                                 table['schema'], table['table'], get_unique_field_name())
-                            d = drop_table_field(dest_d_db_conn,
-                                                 table['schema'], table['table'], get_unique_field_name())
-                            print(output_cli_result(s and d, compensation=12))
+            for db in get_cluster_databases(src_db_conn):
+                output_cli_message(db)
+                print
+                src_d_db_conn = connect('Source', db_name=db)
+                dest_d_db_conn = connect('Destination', db_name=db)
+                with indent(4, quote=' '):
+                    for table in get_database_tables(src_d_db_conn):
+                        output_cli_message("%s.%s" % (table['schema'], table['table']))
+                        s = drop_table_field(
+                            src_d_db_conn, table['schema'], table['table'], get_unique_field_name()
+                        )
+                        d = drop_table_field(
+                            dest_d_db_conn, table['schema'], table['table'], get_unique_field_name()
+                        )
+                        print(output_cli_result(s and d, compensation=12))
 
 

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -166,7 +166,7 @@ def create_replication_sets(db):
         db_schemas = get_schemas(db_conn)
         c = db_conn.cursor()
         c.execute("CREATE EXTENSION pglogical")
-        c.execute("SELECT pglogical.drop_node(node_name := %s, ifexists := false)", ['Source'])
+        c.execute("SELECT pglogical.drop_node(node_name := %s, ifexists := true)", ['Source'])
         c.execute("SELECT pglogical.create_node(node_name := %s, dsn := %s );",
                   ['Source', get_dsn_for_pglogical('Source', db_name=db)])
         c.execute("SELECT pglogical.replication_set_add_all_tables('default', '{%s}'::text[]);" % ','.join(db_schemas))
@@ -174,7 +174,7 @@ def create_replication_sets(db):
                   [db_schemas])
         db_conn.commit()
         return True
-    except:
+    except Exception as e:
         db_conn.rollback()
         return False
 
@@ -204,12 +204,12 @@ def create_pglogical_node(db):
         drop_extension(db_conn, "pglogical")
         c.execute("DROP SCHEMA IF EXISTS pglogical CASCADE")
         c.execute("CREATE EXTENSION pglogical")
-        c.execute("SELECT pglogical.drop_node(node_name := %s, ifexists := false)", ['Destination'])
+        c.execute("SELECT pglogical.drop_node(node_name := %s, ifexists := true)", ['Destination'])
         c.execute("SELECT pglogical.create_node( node_name := %s, dsn := %s );", [
             'Destination', get_dsn_for_pglogical('Destination', db)
         ])
         db_conn.commit()
-    except Error:
+    except Exception as e:
         db_conn.rollback()
         return False
 

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -96,7 +96,7 @@ def start_subscription(db):
             """
             SELECT pglogical.create_subscription(
                                     subscription_name := 'subscription',
-                                    synchronize_structure := true,
+                                    synchronize_structure := false,
                                     synchronize_data := true,
                                     provider_dsn := %s
             );

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -278,7 +278,7 @@ def get_replication_delay():
     dest_cur.execute("SELECT remote_lsn FROM pg_replication_origin_status ORDER BY remote_lsn DESC limit 1;")
     d_lsn_r = dest_cur.fetchone()
     if d_lsn_r:
-        src_cur.execute("SELECT pg_xlog_location_diff(pg_current_xlog_location(), %s)", [d_lsn_r[0]])
+        src_cur.execute("SELECT pg_xlog_location_diff(pg_current_xlog_location(), %s)", d_lsn_r[0])
         diff = src_cur.fetchone()
         return diff
     else:

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -60,7 +60,7 @@ def stop_subscription(db):
     cur = db_conn.cursor()
     try:
         while True:
-            cur.execute("SELECT * FROM pglogical.drop_subscription(subscription_name := %s, ifexists := false)",
+            cur.execute("SELECT * FROM pglogical.drop_subscription(subscription_name := %s, ifexists := true)",
                         ['subscription'])
             if cur.fetchone()[0] == 0:
                 break
@@ -78,7 +78,7 @@ def drop_node(db):
     cur = db_conn.cursor()
     while True:
         try:
-            cur.execute("SELECT * FROM pglogical.drop_node(node_name := 'Destination', ifexists := false);")
+            cur.execute("SELECT * FROM pglogical.drop_node(node_name := 'Destination', ifexists := true);")
         except psycopg2.ProgrammingError:
             break
         if not cur.fetchone()[0]:

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -156,7 +156,7 @@ def setup_pgl_ddl_deploy(db, target):
 
     return True
 
-def clean_pgl_ddl_deploy(db, target):
+def clean_pgl_ddl_deploy(target, db):
     db_conn = connect(target, db)
     db_conn.autocommit = True
     c = db_conn.cursor()

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -254,7 +254,6 @@ def get_setup_result(target, db):
 def get_replication_status(db):
     result = {"result": False, "status": None}
     db_conn = connect('Destination', db_name=db)
-    src_db_conn = connect('Source', db_name=db)
     result["result"] = False
     try:
         cur = db_conn.cursor(cursor_factory=extras.DictCursor)
@@ -264,11 +263,7 @@ def get_replication_status(db):
             result["result"] = True
             result["status"] = r['status']
 
-    except psycopg2.InternalError:
-        result["result"] = False
-    except psycopg2.OperationalError:
-        result["result"] = False
-    except psycopg2.ProgrammingError:
+    except (psycopg2.InternalError, psycopg2.OperationalError, psycopg2.ProgrammingError) as e:
         result["result"] = False
 
     return result

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -178,7 +178,7 @@ def create_replication_sets(db):
     try:
         db_schemas = get_schemas(db_conn)
         c = db_conn.cursor()
-        c.execute("CREATE EXTENSION pglogical")
+        c.execute("CREATE EXTENSION IF NOT EXISTS pglogical")
         c.execute("SELECT pglogical.drop_node(node_name := %s, ifexists := true)", ['Source'])
         c.execute(
             "SELECT pglogical.create_node(node_name := %s, dsn := %s )",
@@ -265,7 +265,7 @@ def get_setup_result(target, db):
             return False
         return r[0]
 
-    except Error:
+    except Exception:
         return False
 
 

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -119,6 +119,7 @@ def setup_pgl_ddl_deploy(db, target):
     """
     Create a trigger on CREATE TABLE/SEQUENCE events in order to replicate them to the Destination Database
     see https://www.2ndquadrant.com/en/resources/pglogical/pglogical-docs/ 2.4.1 Automatic Assignment of Replication Sets for New Tables
+    and https://github.com/enova/pgl_ddl_deploy
 
     :param db:
     :return: boolean

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -115,7 +115,7 @@ def syncronize_sequences(db):
     c.execute("SELECT pglogical.synchronize_sequence( seqoid ) FROM pglogical.sequence_state")
 
 
-def setup_pg_ddl_deploy(db):
+def setup_pgl_ddl_deploy(db):
     """
     Create a trigger on CREATE TABLE/SEQUENCE events in order to replicate them to the Destination Database
     see https://www.2ndquadrant.com/en/resources/pglogical/pglogical-docs/ 2.4.1 Automatic Assignment of Replication Sets for New Tables

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -231,11 +231,8 @@ def create_pglogical_node(db):
         return False;
 
     try:
-        c = db_conn.cursor()
         drop_extension(db_conn, "pglogical")
-        c.execute("BEGIN")
-        c.execute("DROP SCHEMA IF EXISTS pglogical CASCADE")
-        c.execute("DROP EXTENSION IF EXISTS pglogical")
+        c = db_conn.cursor()
         c.execute("CREATE EXTENSION IF NOT EXISTS pglogical")
 
         c.execute("SELECT pglogical.drop_node(node_name := %s, ifexists := true)", ['Destination'])

--- a/pgrepup/helpers/replication.py
+++ b/pgrepup/helpers/replication.py
@@ -156,6 +156,18 @@ def setup_pgl_ddl_deploy(db, target):
 
     return True
 
+def clean_pgl_ddl_deploy(db, target):
+    db_conn = connect(target, db)
+    db_conn.autocommit = True
+    c = db_conn.cursor()
+    c.execute("SELECT pgl_ddl_deploy.undeploy(set_name) FROM pgl_ddl_deploy.set_configs")
+    if not db_conn:
+        return False
+    if not drop_extension(db_conn, "pgl_ddl_deploy"):
+        return False
+
+    return True
+
 
 def create_replication_sets(db):
     db_conn = connect('Source', db)
@@ -195,10 +207,6 @@ def clean_pglogical_setup(target, db):
         return False
     if not drop_extension(db_conn, "pglogical"):
         return False
-
-    c = db_conn.cursor()
-    c.execute("DROP event trigger IF EXISTS trg_pgrepup_replicate_ddl;")
-    c.execute("DROP FUNCTION IF EXISTS pgrepup_replicate_ddl()")
 
     return True
 
@@ -273,6 +281,7 @@ def get_replication_status(db):
             result["status"] = r['status']
 
     except (psycopg2.InternalError, psycopg2.OperationalError, psycopg2.ProgrammingError) as e:
+        print e
         result["result"] = False
 
     return result

--- a/pgrepup/version.py
+++ b/pgrepup/version.py
@@ -19,4 +19,4 @@
 This module contains the current Pgrepup version.
 """
 
-__version__ = '0.3.7'
+__version__ = '0.3.8'

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ install_requires = [
     'docopt >= 0.6.0',
     'python-dateutil',
     'clint >= 0.5.1',
-    'cryptography'
+    'cryptography',
+    'semver',
 ]
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
* add PostgreSQL 10 compatibility see https://wiki.postgresql.org/wiki/New_in_postgres_10#Renaming_of_.22xlog.22_to_.22wal.22_Globally_.28and_location.2Flsn.29
* add usage pgl_ddl_deploy to replicate DDL statements
* add usage sh for systems which not have default right "shell" out of the box (i.e. cygwin, or alpine)
* add usage ifexists := true, for multiple drop_node command running
* improve parsing pg_dumpall version with semver
* add config option app_owner (see https://github.com/enova/pgl_ddl_deploy#full_example) for correctly replicate DDL statements
