### PR TITLE
Fix os.system parameters templating

### DIFF
--- a/pgrepup/commands/setup.py
+++ b/pgrepup/commands/setup.py
@@ -113,8 +113,7 @@ def _setup_source(conn, pg_pass):
     pg_dumpall_schema = "%s/pg_dumpall_schema_%s.sql" % (get_tmp_folder(), uuid.uuid4().hex)
     output_cli_message("Dump globals and schema of all databases")
     pg_dumpall_schema_result = \
-        os.system('sh -c "PGPASSFILE=%(pgpass)s pg_dumpall -U %(user)s -h %(host)s -p%(port)s -s -f %(fname)s ' +
-                  '--if-exists -c"' %
+        os.system('sh -c "PGPASSFILE=%(pgpass)s pg_dumpall -U %(user)s -h %(host)s -p%(port)s -s -f %(fname)s --if-exists -c"' %
                   merge_two_dicts(
                       get_connection_params('Source'),
                       {"fname": pg_dumpall_schema, "pgpass": pg_pass}
@@ -160,8 +159,7 @@ def _setup_destination(conn, pg_pass, source_setup_results):
     if 'pg_dumpall' in source_setup_results:
         restore_schema_result = \
             os.system(
-                'sh -c "PGPASSFILE=%(pgpass)s psql -U %(user)s -h %(host)s -p%(port)s -f %(fname)s -d postgres ' +
-                '>/dev/null 2>&1"'
+                'sh -c "PGPASSFILE=%(pgpass)s psql -U %(user)s -h %(host)s -p%(port)s -f %(fname)s -d postgres >/dev/null 2>&1"'
                 % merge_two_dicts(
                     get_connection_params('Destination'),
                     {"fname": source_setup_results['pg_dumpall'], "pgpass": pg_pass}


### PR DESCRIPTION
Parameters doesn't get mapped if string is splitted with +