### PR TITLE
TypeError: setup() takes no arguments (14 given)

### DIFF
--- a/pgrepup/helpers/docopt_dispatch.py
+++ b/pgrepup/helpers/docopt_dispatch.py
@@ -36,7 +36,10 @@ class Dispatch(object):
 
         for patterns, function in self._functions.items():
             if all(arguments[pattern] for pattern in patterns):
-                function(**self._kwargify(arguments))
+                if function.__name__ == 'setup':
+                    function()
+                else:
+                    function(**self._kwargify(arguments))
                 return
         raise DispatchError('None of dispatch conditions %s is triggered'
                             % self._formated_patterns)


### PR DESCRIPTION
I'm not python programmer and i think that my fix is very strange. But it works.

```
$ pgrepup setup
Pgrepup 0.3.10
Traceback (most recent call last):
  File "/usr/local/bin/pgrepup", line 25, in <module>
    main()
  File "/usr/local/lib/python2.7/dist-packages/pgrepup/cli.py", line 64, in main
    dispatch(__doc__)
  File "/usr/local/lib/python2.7/dist-packages/pgrepup/helpers/docopt_dispatch.py", line 39, in __call__
    function(**self._kwargify(arguments))
TypeError: setup() takes no arguments (14 given)
```